### PR TITLE
HDF5 format for charge density output

### DIFF
--- a/ndarray/Cargo.toml
+++ b/ndarray/Cargo.toml
@@ -11,3 +11,4 @@ types = { path = "../types" }
 dwconsts = { path = "../dwconsts" }
 itertools = "*"
 num = "*"
+hdf5 = "0.8.1"

--- a/ndarray/src/lib.rs
+++ b/ndarray/src/lib.rs
@@ -1,3 +1,7 @@
+use hdf5::File as File_hdf5;
+use hdf5::types::H5Type;
+use num::complex::Complex;
+
 pub mod array2;
 pub use array2::*;
 
@@ -166,6 +170,46 @@ impl<T: Default + Copy + Clone + Zero + std::ops::Mul<Output = T> + std::ops::Su
         for (s, d) in multizip((data.iter(), self.data.iter_mut())) {
             *d = *s;
         }
+    }
+}
+
+
+impl<T: Default + Copy + Clone + H5Type + Into<f64>> Array3<Complex<T>> {
+    /// Save the array to a HDF5 file. The shape, and the real and the imaginary parts of the data are saved in their respective datasets.
+    pub fn save_hdf5(&self, filename: &str) {
+        let file = File_hdf5::create(filename).unwrap();
+
+        // Write shape
+        let _dataset_shape = file.new_dataset_builder()
+            .with_data(&self.shape)
+            .create("shape").unwrap();
+
+        let real_data: Vec<f64> = self.data.iter().map(|&c| c.re.into()).collect();
+        let imag_data: Vec<f64> = self.data.iter().map(|&c| c.im.into()).collect();
+        
+        // Write real part
+        let _dataset_real = file.new_dataset_builder()
+            .with_data(&real_data)
+            .create("real").unwrap();
+        
+        // Write imaginary part
+        let _dataset_imag = file.new_dataset_builder()
+            .with_data(&imag_data)
+            .create("imag").unwrap();
+    }
+
+    /// Load the array from a HDF5 file as saved by the save_hdf5 function.
+    pub fn load_hdf5(&mut self, filename: &str) {
+        let file = File_hdf5::open(filename).unwrap();
+        
+        // Read shape
+        let shape: Vec<usize> = file.dataset("shape").unwrap().read().unwrap().to_vec();
+        self.shape = shape.try_into().unwrap();
+
+        // Read data
+        let real_data: Vec<T> = file.dataset("real").unwrap().read().unwrap().to_vec();
+        let imag_data: Vec<T> = file.dataset("imag").unwrap().read().unwrap().to_vec();
+        self.data = real_data.iter().zip(imag_data).map(|(&r, i)| Complex::new(r, i)).collect();
     }
 }
 

--- a/pw/src/main.rs
+++ b/pw/src/main.rs
@@ -150,15 +150,27 @@ fn main() {
         // set rhog and rho_3d to be the atomic super position
 
         if dwmpi::is_root() {
-            if geom_iter == 1 && std::path::Path::new("out.scf.rho").exists() {
-                if let RHOG::NonSpin(ref mut rhog) = &mut rhog {
-                    if let RHOR::NonSpin(ref mut rho_3d) = &mut rho_3d {
-                        rho_3d.load("out.scf.rho");
-                        rgtrans.r3d_to_g1d(&gvec, &pwden, rho_3d.as_slice(), rhog);
+            if geom_iter == 1 {
+                if std::path::Path::new("out.scf.rho.hdf5").exists() {
+                    if let RHOG::NonSpin(ref mut rhog) = &mut rhog {
+                        if let RHOR::NonSpin(ref mut rho_3d) = &mut rho_3d {
+                            rho_3d.load_hdf5("out.scf.rho.hdf5");
+                            rgtrans.r3d_to_g1d(&gvec, &pwden, rho_3d.as_slice(), rhog);
+                        }
                     }
-                }
 
-                println!("   load charge density from out.scf.rho");
+                    println!("   load charge density from out.scf.rho.hdf5");
+                }
+                else if std::path::Path::new("out.scf.rho").exists() {
+                    if let RHOG::NonSpin(ref mut rhog) = &mut rhog {
+                        if let RHOR::NonSpin(ref mut rho_3d) = &mut rho_3d {
+                            rho_3d.load("out.scf.rho");
+                            rgtrans.r3d_to_g1d(&gvec, &pwden, rho_3d.as_slice(), rhog);
+                        }
+                    }
+
+                    println!("   load charge density from out.scf.rho");
+                }
             } else {
                 density_driver.from_atomic_super_position(
                     &pots,
@@ -413,9 +425,12 @@ fn main() {
             if control.get_save_rho() {
                 if let RHOR::NonSpin(ref rho_3d) = &rho_3d {
                     rho_3d.save("out.scf.rho");
+                    rho_3d.save_hdf5("out.scf.rho.hdf5");
                 } else if let RHOR::Spin(ref rho_3d_up, ref rho_3d_dn) = &rho_3d {
                     rho_3d_up.save("out.scf.rho.up");
+                    rho_3d_up.save_hdf5("out.scf.rho.up.hdf5");
                     rho_3d_dn.save("out.scf.rho.dn");
+                    rho_3d_dn.save_hdf5("out.scf.rho.dn.hdf5");
                 }
             }
 


### PR DESCRIPTION
This pull-request is related to issue #6.

Here the functionality to save and load a Array3 to and from a HDF5 file is added. The Array3 object needs to contain data that is of a complex HDF5-compatible type, i.e. we implement the `save_hdf5` and `load_hdf5` function for

```Rust
impl<T: Default + Copy + Clone + H5Type + Into<f64>> Array3<Complex<T>>
```

These functions are then used in the [pw/main.rs](https://github.com/dftworks/dftworks/blob/main/pw/src/main.rs) file to load and save the charge density.