### PR TITLE
HDF5 support for wavefunction and overall generalization

### DIFF
--- a/control/src/lib.rs
+++ b/control/src/lib.rs
@@ -43,6 +43,7 @@ pub struct Control {
     task: String,        // scf, band
     restart: bool,
     save_rho: bool,
+    save_wfc: bool,
     eigen_solver: String, // sd, psd, cg, pcg, arpack, davidson
 
     davidson_ndim: usize,
@@ -245,6 +246,7 @@ impl Control {
             "band" => {
                 self.restart = true;
                 self.save_rho = false;
+                self.save_wfc = false;
                 //self.scf_max_iter = 1;
             }
 
@@ -262,6 +264,10 @@ impl Control {
 
     pub fn get_save_rho(&self) -> bool {
         self.save_rho
+    }
+
+    pub fn get_save_wfc(&self) -> bool {
+        self.save_wfc
     }
 
     pub fn get_occ_inversion(&self) -> f64 {
@@ -282,6 +288,7 @@ impl Control {
         self.geom_optim_stress_tolerance = 0.05; // kbar
 
         self.save_rho = true;
+        self.save_wfc = true;
 
         self.ecut_wfc = 400.0 * EV_TO_HA; // ev in in.ctrl, need to convert to HA
         self.ecut_rho = 4.0 * self.ecut_wfc;
@@ -468,6 +475,10 @@ impl Control {
 
                 "save_rho" => {
                     self.save_rho = s[1].parse().unwrap();
+                }
+
+                "save_wfc" => {
+                    self.save_wfc = s[1].parse().unwrap();
                 }
 
                 "eigen_solver" => {

--- a/dfttypes/Cargo.toml
+++ b/dfttypes/Cargo.toml
@@ -11,4 +11,7 @@ types = { path = "../types" }
 matrix = { path = "../matrix" }
 ndarray = { path = "../ndarray" }
 kscf = { path = "../kscf" }
+pwbasis = { path = "../pwbasis" }
+lattice = { path = "../lattice" }
 enum-as-inner = "*"
+hdf5 = "0.8.1"

--- a/lattice/Cargo.toml
+++ b/lattice/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 matrix = { path = "../matrix" }
 vector3 = { path = "../vector3" }
 itertools = "*"
+hdf5 = "0.8.1"

--- a/lattice/src/lib.rs
+++ b/lattice/src/lib.rs
@@ -160,6 +160,11 @@ impl Lattice {
             }
         }
     }
+
+    /// Save the PWBasis to a HDF5 file.
+    pub fn save_hdf5(&self, group: &mut hdf5::Group) {
+        self.data.save_hdf5(group)
+    }
 }
 
 impl fmt::Display for Lattice {

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -12,3 +12,4 @@ types = { path = "../types" }
 lapack_sys = { path = "../lapack_sys" }
 itertools = "*"
 num-traits = "*"
+hdf5 = "0.8.1"

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -286,6 +286,9 @@ impl<T: Debug + Display> fmt::Display for Matrix<T> {
     }
 }
 
+// TODO: Implement save_hdf5 and load_hdf5 here if the support of complex types in the hdf5 crate is released.
+//       See: https://github.com/aldanor/hdf5-rust/pull/210 and https://github.com/aldanor/hdf5-rust/issues/262
+
 #[test]
 fn test_matrix() {
     let mut m: Matrix<f64> = Matrix::<f64>::from_row_slice(2, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);

--- a/matrix/src/matrix_c64.rs
+++ b/matrix/src/matrix_c64.rs
@@ -3,6 +3,7 @@ use dwconsts::*;
 use itertools::multizip;
 use lapack_sys::*;
 use num_traits::Zero;
+use hdf5::File as File_hdf5;
 use std::ops::AddAssign;
 use std::ops::Mul;
 use types::c64;
@@ -137,6 +138,54 @@ impl Matrix<c64> {
         }
 
         mat
+    }
+
+    /// Save the matrix to a HDF5 file. The shape (an array [nrow, ncol]), and the real and the imaginary parts of the data are saved in their respective datasets.
+    pub fn save_hdf5(&self, filename: &str) {
+        let file = File_hdf5::create(filename).unwrap();
+
+        // Write nrow
+        let _dataset_nrow = file
+            .new_dataset_builder()
+            .with_data(&[self.nrow, self.ncol])
+            .create("shape")
+            .unwrap();
+
+        let real_data: Vec<f64> = self.data.iter().map(|&c| c.re.into()).collect();
+        let imag_data: Vec<f64> = self.data.iter().map(|&c| c.im.into()).collect();
+
+        // Write real part
+        let _dataset_real = file
+            .new_dataset_builder()
+            .with_data(&real_data)
+            .create("real")
+            .unwrap();
+
+        // Write imaginary part
+        let _dataset_imag = file
+            .new_dataset_builder()
+            .with_data(&imag_data)
+            .create("imag")
+            .unwrap();
+    }
+
+    /// Load the array from a HDF5 file as saved by the save_hdf5 function.
+    pub fn load_hdf5(&mut self, filename: &str) {
+        let file = File_hdf5::open(filename).unwrap();
+
+        // Read nrow and ncol
+        let shape: Vec<usize> = file.dataset("shape").unwrap().read().unwrap().to_vec();
+        self.nrow = *shape.get(0).unwrap();
+        self.ncol = *shape.get(1).unwrap();
+
+        // Read data
+        let real_data: Vec<f64> = file.dataset("real").unwrap().read().unwrap().to_vec();
+        let imag_data: Vec<f64> = file.dataset("imag").unwrap().read().unwrap().to_vec();
+        self.data = real_data
+            .iter()
+            .zip(imag_data)
+            .map(|(&r, i)| c64::new(r, i))
+            .collect();
     }
 }
 

--- a/matrix/src/matrix_f64.rs
+++ b/matrix/src/matrix_f64.rs
@@ -137,4 +137,32 @@ impl Matrix<f64> {
     pub fn sum(&self) -> f64 {
         return self.data.iter().sum();
     }
+
+    /// Save the matrix to a HDF5 file. The shape (an array [nrow, ncol]), and the real and the imaginary parts of the data are saved in their respective datasets.
+    pub fn save_hdf5(&self, group: &mut hdf5::Group) {
+        // Write nrow, ncol
+        let _dataset_nrow = group
+            .new_dataset_builder()
+            .with_data(&[self.nrow, self.ncol])
+            .create("shape")
+            .unwrap();
+
+        // Write data
+        let _dataset_real = group
+            .new_dataset_builder()
+            .with_data(&self.data)
+            .create("data")
+            .unwrap();
+    }
+
+    /// Load the array from a HDF5 group as saved by the save_hdf5 function.
+    pub fn load_hdf5(&mut self, group: &mut hdf5::Group) {
+        // Read nrow and ncol
+        let shape: Vec<usize> = group.dataset("shape").unwrap().read().unwrap().to_vec();
+        self.nrow = *shape.get(0).unwrap();
+        self.ncol = *shape.get(1).unwrap();
+
+        // Read data
+        self.data = group.dataset("data").unwrap().read().unwrap().to_vec();
+    }
 }

--- a/ndarray/src/array3_c64.rs
+++ b/ndarray/src/array3_c64.rs
@@ -4,7 +4,6 @@ use itertools::multizip;
 
 use types::*;
 
-use hdf5::File as File_hdf5;
 use std::convert::TryInto;
 
 impl Array3<c64> {
@@ -95,45 +94,41 @@ impl Array3<c64> {
     }
 
     /// Save the array to a HDF5 file. The shape, and the real and the imaginary parts of the data are saved in their respective datasets.
-    pub fn save_hdf5(&self, filename: &str) {
-        let file = File_hdf5::create(filename).unwrap();
-
+    pub fn save_hdf5(&self, group: &mut hdf5::Group) {
         // Write shape
-        let _dataset_shape = file
+        let _dataset_shape = group
             .new_dataset_builder()
             .with_data(&self.shape)
             .create("shape")
             .unwrap();
 
-        let real_data: Vec<f64> = self.data.iter().map(|&c| c.re.into()).collect();
-        let imag_data: Vec<f64> = self.data.iter().map(|&c| c.im.into()).collect();
+        let real_data: Vec<f64> = self.data.iter().map(|&c| c.re).collect();
+        let imag_data: Vec<f64> = self.data.iter().map(|&c| c.im).collect();
 
         // Write real part
-        let _dataset_real = file
+        let _dataset_real = group
             .new_dataset_builder()
             .with_data(&real_data)
             .create("real")
             .unwrap();
 
         // Write imaginary part
-        let _dataset_imag = file
+        let _dataset_imag = group
             .new_dataset_builder()
             .with_data(&imag_data)
             .create("imag")
             .unwrap();
     }
 
-    /// Load the array from a HDF5 file as saved by the save_hdf5 function.
-    pub fn load_hdf5(&mut self, filename: &str) {
-        let file = File_hdf5::open(filename).unwrap();
-
+    /// Load the array from a HDF5 group as saved by the save_hdf5 function.
+    pub fn load_hdf5(&mut self, group: &mut hdf5::Group) {
         // Read shape
-        let shape: Vec<usize> = file.dataset("shape").unwrap().read().unwrap().to_vec();
+        let shape: Vec<usize> = group.dataset("shape").unwrap().read().unwrap().to_vec();
         self.shape = shape.try_into().unwrap();
 
         // Read data
-        let real_data: Vec<f64> = file.dataset("real").unwrap().read().unwrap().to_vec();
-        let imag_data: Vec<f64> = file.dataset("imag").unwrap().read().unwrap().to_vec();
+        let real_data: Vec<f64> = group.dataset("real").unwrap().read().unwrap().to_vec();
+        let imag_data: Vec<f64> = group.dataset("imag").unwrap().read().unwrap().to_vec();
         self.data = real_data
             .iter()
             .zip(imag_data)

--- a/pw/src/main.rs
+++ b/pw/src/main.rs
@@ -422,6 +422,29 @@ fn main() {
             crystal.output();
         }
 
+        // save wavefunction
+        if control.get_save_wfc() {
+            if let VKEigenVector::NonSpin(ref vkevecs) = &vkevecs {
+                for (im, m) in vkevecs.iter().enumerate() {
+                    let ik = ik_first + im;
+                    let filename = format!("out.wfc.k.{}.hdf5", ik);
+                    m.save_hdf5(&filename);
+                }
+            } else if let VKEigenVector::Spin(ref vkevecs_up, ref vkevecs_dn) = &vkevecs {
+                for (im, m) in vkevecs_up.iter().enumerate() {
+                    let ik = ik_first + im;
+                    let filename = format!("out.wfc.up.k.{}.hdf5", ik);
+                    m.save_hdf5(&filename);
+                }
+                for (im, m) in vkevecs_dn.iter().enumerate() {
+                    let ik = ik_first + im;
+                    let filename = format!("out.wfc.dn.k.{}.hdf5", ik);
+                    m.save_hdf5(&filename);
+                }
+            }
+        }
+        
+
         // if converged, then exit
 
         let force_max = force::get_max_force(&force_total);

--- a/pwbasis/Cargo.toml
+++ b/pwbasis/Cargo.toml
@@ -11,3 +11,4 @@ lattice = { path = "../lattice" }
 gvector = { path = "../gvector" }
 utility = { path = "../utility" }
 vector3 = { path = "../vector3" }
+hdf5 = "0.8.1"

--- a/pwbasis/src/lib.rs
+++ b/pwbasis/src/lib.rs
@@ -64,6 +64,43 @@ impl PWBasis {
             kg,
         }
     }
+
+    /// Save the PWBasis to a HDF5 file.
+    pub fn save_hdf5(&self, group: &mut hdf5::Group) {
+        let dataset_pwbasis = group
+            .new_dataset_builder()
+            .with_data(&self.get_kg())
+            .create("kg")
+            .unwrap();
+
+        dataset_pwbasis
+            .new_attr_builder()
+            .with_data(&self.get_k_cart().to_vec())
+            .create("k_cart")
+            .unwrap();
+
+        let int_size = match usize::BITS {
+            32 => hdf5::types::IntSize::U4,
+            64 => hdf5::types::IntSize::U8,
+            _ => panic!("Unknown usize size"),
+        };
+
+        dataset_pwbasis
+            .new_attr_builder()
+            .empty_as(&hdf5::types::TypeDescriptor::Unsigned(int_size))
+            .create("k_index")
+            .unwrap()
+            .write_scalar(&self.get_k_index())
+            .unwrap();
+
+        dataset_pwbasis
+            .new_attr_builder()
+            .empty_as(&hdf5::types::TypeDescriptor::Unsigned(int_size))
+            .create("n_pw")
+            .unwrap()
+            .write_scalar(&self.get_n_plane_waves())
+            .unwrap();
+    }
 }
 
 fn compute_kg(gvec: &GVector, xk: Vector3f64, gindex: &[usize], kg: &mut [f64]) {

--- a/test_example/si-oncv/scf/in.ctrl
+++ b/test_example/si-oncv/scf/in.ctrl
@@ -1,6 +1,7 @@
 symmetry = false
 
 save_rho = true
+save_wfc = true
 
 kpts_scheme = kmesh
 


### PR DESCRIPTION
Main changes are:
- Adding a `save_wfc` flag to the input file by adding a bool value to *control/lib.rs*
- Main hdf5 saving and loading is now implemented in *dfttypes/lib.rs* as functions on `VKEigenVector` and `RHOR`. Saving and loading specific matrix and array object is implemented in their respective files, i.e. in *matrix/matrix_c64.rs*, *matrix/matrix_f64.rs*, *lattice/lib.rs*, *ndarray/array3_c64.rs* and *pwbasis/lib.rs*
- Besides the wavefunction and density coefficients, we now save additional information about the plane-wave basis and the reciprocal lattice. Each information piece is saved and loaded in and from a hdf5 group with the name of the information piece, e.g. we save a hdf5 group named PWBasis for the `PWBasis` object.

Aspects of further implementation:
- Although a `load_hdf5` function is implemented for `RHOR` in *dfttypes/lib.rs*, it is currently only able to load spin-unpolarized densities. For spin-polarized densities we need to load from two files because we currently save the spin-up and spin-down densities to different files in the `save_hdf5` function. This means that the function signature of `load_hdf5` needs to be different for spin-unpolarized and spin-polarized densities because we need to load from one or two files, respectively. Possible solutions are: saving spin-polarized densities into only one file instead of two files. Or, defining a type that handles the one or two filenames. The latter could be implemented as follows:
```rust
pub enum FilenameTypes<'a> {
    NonSpin(&'a str),
    Spin(&'a str, &'a str),
}

pub fn load_hdf5(&mut self, filename: FilenameTypes) {
```
- The rust hdf5 crate natively supports complex values on the development GitHub branch. When this gets released, the `save_hdf5` and `load_hdf5` in *matrix/matrix_c64.rs* and *matrix/matrix_f64.rs* can be moved to *matrix/lib.rs*.

**I think the changes presented here need to be carefully reviewed such that they align with what the direction of dftworks is concerning the HDF5 support.**

# Related issues
#6 