### PR TITLE
HDF5 support API generalization

### DIFF
--- a/dfttypes/src/lib.rs
+++ b/dfttypes/src/lib.rs
@@ -77,8 +77,63 @@ impl VKEigenVector {
         }
     }
 
-    pub fn load_hdf5(&mut self) {
-        todo!("Wavefunction cannot be loaded yet!");
+    pub fn load_hdf5(is_spin: bool, ik_first: usize, ik_last: usize) -> (Vec<PWBasis>, Lattice, VKEigenVector) {
+        match is_spin {
+            false => {
+                let mut eigen_vecs = Vec::<Matrix<c64>>::new();
+                let mut pwbasis_vec = Vec::<PWBasis>::new();
+                let mut blatt = Lattice::default();
+
+                for i in ik_first..ik_last {
+                    let filename = format!("out.wfc.up.k.{}.hdf5", i);
+                    let hdf5_file = hdf5::File::open(filename).unwrap();
+
+                    let group_tmp = hdf5_file.group("EigenVector").unwrap();
+                    let eigen_vec_tmp = Matrix::<c64>::load_hdf5(&group_tmp);
+                    eigen_vecs.push(eigen_vec_tmp);
+
+                    // Load PWBasis information
+                    let group_tmp = hdf5_file.create_group("PWBasis").unwrap();
+                    let pwbasis_tmp = PWBasis::load_hdf5(&group_tmp);
+                    pwbasis_vec.push(pwbasis_tmp);
+
+                    // Load reciprocal lattice
+                    let group_tmp = hdf5_file.group("BLattice").unwrap();
+                    blatt = Lattice::load_hdf5(&group_tmp);
+                }
+                (pwbasis_vec, blatt, VKEigenVector::NonSpin(eigen_vecs))
+            },
+            true => {
+                let mut eigen_vecs_up = Vec::<Matrix<c64>>::new();
+                let mut eigen_vecs_dn = Vec::<Matrix<c64>>::new();
+                let mut pwbasis_vec = Vec::<PWBasis>::new();
+                let mut blatt = Lattice::default();
+
+                for i in ik_first..ik_last {
+                    let filename = format!("out.wfc.up.k.{}.hdf5", i);
+                    let hdf5_file = hdf5::File::open(filename).unwrap();
+
+                    let group_tmp = hdf5_file.group("EigenVector").unwrap();
+                    eigen_vecs_up.push(Matrix::<c64>::load_hdf5(&group_tmp));
+
+                    // Load PWBasis information
+                    let group_tmp = hdf5_file.group("PWBasis").unwrap();
+                    pwbasis_vec.push(PWBasis::load_hdf5(&group_tmp));
+
+                    // Load reciprocal lattice
+                    let group_tmp = hdf5_file.group("BLattice").unwrap();
+                    blatt = Lattice::load_hdf5(&group_tmp);
+                }
+                for i in ik_first..ik_last {
+                    let filename = format!("out.wfc.dn.k.{}.hdf5", i);
+                    let hdf5_file = hdf5::File::open(filename).unwrap();
+
+                    let group_tmp = hdf5_file.group("EigenVector").unwrap();
+                    eigen_vecs_dn.push(Matrix::<c64>::load_hdf5(&group_tmp));
+                }
+                (pwbasis_vec, blatt, VKEigenVector::Spin(eigen_vecs_up, eigen_vecs_dn))
+            },
+        }
     }
 }
 
@@ -137,29 +192,33 @@ impl RHOR {
         }
     }
 
-    pub fn load_hdf5(&mut self) -> Lattice {
-        match self {
-            RHOR::NonSpin(rho_3d) => {
+    pub fn load_hdf5(is_spin: bool) -> (Lattice, RHOR) {
+        match is_spin {
+            false => {
                 let hdf5_file = hdf5::File::open("out.scf.rho.hdf5").unwrap();
 
                 let group_tmp = hdf5_file.group("RhoR").unwrap();
-                *rho_3d = Array3::<c64>::load_hdf5(&group_tmp);
+                let rho_3d = Array3::<c64>::load_hdf5(&group_tmp);
 
                 let group_tmp = hdf5_file.group("BLattice").unwrap();
-                Lattice::load_hdf5(&group_tmp)
+                (Lattice::load_hdf5(&group_tmp), RHOR::NonSpin(rho_3d))
             }
-            RHOR::Spin(rho_3d_up, rho_3d_dn) => {
+            true => {
+                // ---------------------- UP ----------------------
                 let hdf5_file_up = hdf5::File::open("out.scf.rho.up.hdf5").unwrap();
-                let hdf5_file_dn = hdf5::File::open("out.scf.rho.dn.hdf5").unwrap();
 
                 let group_tmp = hdf5_file_up.group("RhoR").unwrap();
-                *rho_3d_up = Array3::<c64>::load_hdf5(&group_tmp);
+                let rho_3d_up = Array3::<c64>::load_hdf5(&group_tmp);
+
+                // ---------------------- DOWN ----------------------
+                let hdf5_file_dn = hdf5::File::open("out.scf.rho.dn.hdf5").unwrap();
 
                 let group_tmp = hdf5_file_dn.group("RhoR").unwrap();
-                *rho_3d_dn = Array3::<c64>::load_hdf5(&group_tmp);
+                let rho_3d_dn = Array3::<c64>::load_hdf5(&group_tmp);
 
+                // Load reciprocal lattice only from down-spin file, since it is the same for up-spin
                 let group_tmp = hdf5_file_up.group("BLattice").unwrap();
-                Lattice::load_hdf5(&group_tmp)
+                (Lattice::load_hdf5(&group_tmp), RHOR::Spin(rho_3d_up, rho_3d_dn))
             }
         }
     }

--- a/dfttypes/src/lib.rs
+++ b/dfttypes/src/lib.rs
@@ -84,7 +84,7 @@ impl VKEigenVector {
                 let mut pwbasis_vec = Vec::<PWBasis>::new();
                 let mut blatt = Lattice::default();
 
-                for i in ik_first..ik_last {
+                for i in ik_first..=ik_last {
                     let filename = format!("out.wfc.up.k.{}.hdf5", i);
                     let hdf5_file = hdf5::File::open(filename).unwrap();
 
@@ -109,7 +109,7 @@ impl VKEigenVector {
                 let mut pwbasis_vec = Vec::<PWBasis>::new();
                 let mut blatt = Lattice::default();
 
-                for i in ik_first..ik_last {
+                for i in ik_first..=ik_last {
                     let filename = format!("out.wfc.up.k.{}.hdf5", i);
                     let hdf5_file = hdf5::File::open(filename).unwrap();
 
@@ -124,7 +124,7 @@ impl VKEigenVector {
                     let group_tmp = hdf5_file.group("BLattice").unwrap();
                     blatt = Lattice::load_hdf5(&group_tmp);
                 }
-                for i in ik_first..ik_last {
+                for i in ik_first..=ik_last {
                     let filename = format!("out.wfc.dn.k.{}.hdf5", i);
                     let hdf5_file = hdf5::File::open(filename).unwrap();
 

--- a/dfttypes/src/lib.rs
+++ b/dfttypes/src/lib.rs
@@ -76,6 +76,10 @@ impl VKEigenVector {
             }
         }
     }
+
+    pub fn load_hdf5(&mut self) {
+        todo!("Wavefunction cannot be loaded yet!");
+    }
 }
 
 #[derive(EnumAsInner)]
@@ -133,16 +137,29 @@ impl RHOR {
         }
     }
 
-    pub fn load_hdf5(&mut self, filename: &str) {
+    pub fn load_hdf5(&mut self) -> Lattice {
         match self {
             RHOR::NonSpin(rho_3d) => {
-                let hdf5_file = hdf5::File::open(filename).unwrap();
+                let hdf5_file = hdf5::File::open("out.scf.rho.hdf5").unwrap();
 
-                let mut group_tmp = hdf5_file.group("RhoR").unwrap();
-                rho_3d.load_hdf5(&mut group_tmp);
+                let group_tmp = hdf5_file.group("RhoR").unwrap();
+                *rho_3d = Array3::<c64>::load_hdf5(&group_tmp);
+
+                let group_tmp = hdf5_file.group("BLattice").unwrap();
+                Lattice::load_hdf5(&group_tmp)
             }
-            RHOR::Spin(_rho_3d_up, _rho_3d_dn) => {
-                todo!("Spin-polarized densities cannot be loaded yet!")
+            RHOR::Spin(rho_3d_up, rho_3d_dn) => {
+                let hdf5_file_up = hdf5::File::open("out.scf.rho.up.hdf5").unwrap();
+                let hdf5_file_dn = hdf5::File::open("out.scf.rho.dn.hdf5").unwrap();
+
+                let group_tmp = hdf5_file_up.group("RhoR").unwrap();
+                *rho_3d_up = Array3::<c64>::load_hdf5(&group_tmp);
+
+                let group_tmp = hdf5_file_dn.group("RhoR").unwrap();
+                *rho_3d_dn = Array3::<c64>::load_hdf5(&group_tmp);
+
+                let group_tmp = hdf5_file_up.group("BLattice").unwrap();
+                Lattice::load_hdf5(&group_tmp)
             }
         }
     }

--- a/lattice/src/lib.rs
+++ b/lattice/src/lib.rs
@@ -161,9 +161,16 @@ impl Lattice {
         }
     }
 
-    /// Save the PWBasis to a HDF5 file.
+    /// Save the lattice to a HDF5 file.
     pub fn save_hdf5(&self, group: &mut hdf5::Group) {
-        self.data.save_hdf5(group)
+        self.data.save_hdf5(group);
+    }
+
+    /// Load the lattice from a HDF5 file.
+    pub fn load_hdf5(group: &hdf5::Group) -> Self {
+        Lattice {
+            data: Matrix::<f64>::load_hdf5(group),
+        }
     }
 }
 

--- a/matrix/src/matrix_c64.rs
+++ b/matrix/src/matrix_c64.rs
@@ -168,20 +168,24 @@ impl Matrix<c64> {
     }
 
     /// Load the array from a HDF5 group as saved by the save_hdf5 function.
-    pub fn load_hdf5(&mut self, group: &mut hdf5::Group) {
+    pub fn load_hdf5(group: &hdf5::Group) -> Self {
+        let mut mat = Self::default();
+
         // Read nrow and ncol
         let shape: Vec<usize> = group.dataset("shape").unwrap().read().unwrap().to_vec();
-        self.nrow = *shape.get(0).unwrap();
-        self.ncol = *shape.get(1).unwrap();
+        mat.nrow = *shape.get(0).unwrap();
+        mat.ncol = *shape.get(1).unwrap();
 
         // Read data
         let real_data: Vec<f64> = group.dataset("real").unwrap().read().unwrap().to_vec();
         let imag_data: Vec<f64> = group.dataset("imag").unwrap().read().unwrap().to_vec();
-        self.data = real_data
+        mat.data = real_data
             .iter()
             .zip(imag_data)
             .map(|(&r, i)| c64::new(r, i))
             .collect();
+
+        mat
     }
 }
 

--- a/matrix/src/matrix_f64.rs
+++ b/matrix/src/matrix_f64.rs
@@ -156,13 +156,17 @@ impl Matrix<f64> {
     }
 
     /// Load the array from a HDF5 group as saved by the save_hdf5 function.
-    pub fn load_hdf5(&mut self, group: &mut hdf5::Group) {
+    pub fn load_hdf5(group: &hdf5::Group) -> Self {
+        let mut mat = Self::default();
+
         // Read nrow and ncol
         let shape: Vec<usize> = group.dataset("shape").unwrap().read().unwrap().to_vec();
-        self.nrow = *shape.get(0).unwrap();
-        self.ncol = *shape.get(1).unwrap();
+        mat.nrow = *shape.get(0).unwrap();
+        mat.ncol = *shape.get(1).unwrap();
 
         // Read data
-        self.data = group.dataset("data").unwrap().read().unwrap().to_vec();
+        mat.data = group.dataset("data").unwrap().read().unwrap().to_vec();
+
+        mat
     }
 }

--- a/ndarray/src/array3_c64.rs
+++ b/ndarray/src/array3_c64.rs
@@ -121,19 +121,23 @@ impl Array3<c64> {
     }
 
     /// Load the array from a HDF5 group as saved by the save_hdf5 function.
-    pub fn load_hdf5(&mut self, group: &mut hdf5::Group) {
+    pub fn load_hdf5(group: &hdf5::Group) -> Self {
+        let mut arr = Self::default();
+
         // Read shape
         let shape: Vec<usize> = group.dataset("shape").unwrap().read().unwrap().to_vec();
-        self.shape = shape.try_into().unwrap();
+        arr.shape = shape.try_into().unwrap();
 
         // Read data
         let real_data: Vec<f64> = group.dataset("real").unwrap().read().unwrap().to_vec();
         let imag_data: Vec<f64> = group.dataset("imag").unwrap().read().unwrap().to_vec();
-        self.data = real_data
+        arr.data = real_data
             .iter()
             .zip(imag_data)
             .map(|(&r, i)| c64::new(r, i))
             .collect();
+
+        arr
     }
 }
 

--- a/pw/src/main.rs
+++ b/pw/src/main.rs
@@ -152,7 +152,7 @@ fn main() {
         if dwmpi::is_root() {
             if geom_iter == 1 && std::path::Path::new("out.scf.rho.hdf5").exists() {
                 if let RHOG::NonSpin(ref mut rhog) = &mut rhog {
-                    rho_3d.load_hdf5("out.scf.rho.hdf5");
+                    rho_3d.load_hdf5();
                     if let RHOR::NonSpin(data) = &mut rho_3d {
                         rgtrans.r3d_to_g1d(&gvec, &pwden, data.as_slice(), rhog);
                     }

--- a/pw/src/main.rs
+++ b/pw/src/main.rs
@@ -152,7 +152,7 @@ fn main() {
         if dwmpi::is_root() {
             if geom_iter == 1 && std::path::Path::new("out.scf.rho.hdf5").exists() {
                 if let RHOG::NonSpin(ref mut rhog) = &mut rhog {
-                    rho_3d.load_hdf5();
+                    rho_3d = RHOR::load_hdf5(control.is_spin()).1;
                     if let RHOR::NonSpin(data) = &mut rho_3d {
                         rgtrans.r3d_to_g1d(&gvec, &pwden, data.as_slice(), rhog);
                     }


### PR DESCRIPTION
Main changes are:
- RhoR load_hdf5 function does not need a filename anymore
- The gindex from PWBasis is now saved to th hdf5 file
- load_hdf5 functions for matrix, array3, pwbasis and lattice now return a new object instead of changing an existing object.

Aspects of further implementation:
- The `load_hdf5` for VKEigenVector is still a placeholder. The implementation needs to load from multiple files, one file for each k-point. A possible implementation could search the folder for all *out.wfc.k.x.hdf5* files and load them. Or, we could introduce `start_k` and `end_k` as function arguments which determine which k-point indices are loaded. Further, how do we handle the `ik_first` variable when loading because `ik_first` is relevant for saving and setting the filenames?

# Related issues and PRs
#6 
#9 