### PR TITLE
Fix runtime bootstrap errors and add project-local skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Project Skills
+
+Project-local skills for this repository live under `skills/`.
+
+### Available skills
+
+- `dftworks-runtime-review`: Use when reviewing DFTWorks runtime-path changes in `pw`, `control`, `crystal`, `pspot`, restart/checkpoint, or output/finalization code.
+- `dftworks-runtime-hardening`: Use when implementing and validating fixes for DFTWorks runtime-path issues such as panic-based loaders, swallowed errors, incorrect exit behavior, or weak bootstrap validation.
+
+### Usage notes
+
+- If the user names one of these skills, or the task clearly matches, open that skill's `SKILL.md` and follow it.
+- Prefer these project-local skills over generic review/fix workflows for DFTWorks runtime-path work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Project-local skills for this repository live under `skills/`.
 
 - `dftworks-runtime-review`: Use when reviewing DFTWorks runtime-path changes in `pw`, `control`, `crystal`, `pspot`, restart/checkpoint, or output/finalization code.
 - `dftworks-runtime-hardening`: Use when implementing and validating fixes for DFTWorks runtime-path issues such as panic-based loaders, swallowed errors, incorrect exit behavior, or weak bootstrap validation.
+- `dftworks-regression-testing`: Use when selecting and running the right DFTWorks validation and regression matrix for `pw`, `workflow`, input/bootstrap, symmetry, XC-mode, or Wannier-related changes.
 
 ### Usage notes
 

--- a/crystal/src/lib.rs
+++ b/crystal/src/lib.rs
@@ -11,6 +11,42 @@ use std::{
     io::{BufRead, BufReader},
 };
 
+fn strip_comment(line: &str) -> &str {
+    line.split('#').next().unwrap_or(line)
+}
+
+fn parse_bool_mask(token: &str, path: &str, line_no: usize, axis: &str) -> Result<f64, String> {
+    match token.trim().to_ascii_lowercase().as_str() {
+        "t" => Ok(1.0),
+        "f" => Ok(0.0),
+        other => Err(format!(
+            "{}:{}: invalid cell mask '{}' for {}; expected T or F",
+            path, line_no, other, axis
+        )),
+    }
+}
+
+fn parse_f64_token(
+    tokens: &[&str],
+    index: usize,
+    path: &str,
+    line_no: usize,
+    field: &str,
+) -> Result<f64, String> {
+    let raw = tokens.get(index).ok_or_else(|| {
+        format!(
+            "{}:{}: missing {} (expected enough columns on this line)",
+            path, line_no, field
+        )
+    })?;
+    raw.parse::<f64>().map_err(|err| {
+        format!(
+            "{}:{}: failed to parse {} from '{}': {}",
+            path, line_no, field, raw, err
+        )
+    })
+}
+
 // Crystal structure container.
 //
 // Coordinates:
@@ -188,156 +224,175 @@ impl Crystal {
     }
 
     pub fn read_file(&mut self, inpfile: &str) {
+        if let Err(err) = self.try_read_file(inpfile) {
+            panic!("{}", err);
+        }
+    }
+
+    pub fn try_read_file(&mut self, inpfile: &str) -> Result<(), String> {
         // Parse in.crystal with format:
         // line 1: scale_a scale_b scale_c
         // line 2-4: lattice vectors + T/F mask flags per Cartesian component
         // remaining lines: species x y z (fractional atomic positions)
-        let file = File::open(inpfile).unwrap();
+        let file = File::open(inpfile)
+            .map_err(|err| format!("failed to read '{}': {}", inpfile, err))?;
         let lines = BufReader::new(file).lines();
 
-        self.atom_positions = Vec::new();
-        self.atom_species = Vec::new();
+        let mut atom_positions = Vec::new();
+        let mut atom_species = Vec::new();
 
         let mut vec_a = [0.0; 3];
         let mut vec_b = [0.0; 3];
         let mut vec_c = [0.0; 3];
 
-        self.cell_mask = Matrix::new(3, 3);
+        let mut cell_mask = Matrix::new(3, 3);
+        let mut scale_a = 0.0;
+        let mut scale_b = 0.0;
+        let mut scale_c = 0.0;
+        let mut content_line_index = 0usize;
 
-        for (i, line) in lines.enumerate() {
-            let s: Vec<&str> = line.as_ref().unwrap().split_whitespace().collect();
+        for (line_idx, line_res) in lines.enumerate() {
+            let line_no = line_idx + 1;
+            let line = line_res
+                .map_err(|err| format!("{}:{}: failed to read line: {}", inpfile, line_no, err))?;
+            let stripped = strip_comment(&line);
+            let s: Vec<&str> = stripped.split_whitespace().collect();
+            if s.is_empty() {
+                continue;
+            }
 
-            match i {
+            match content_line_index {
                 0 => {
+                    if s.len() < 3 {
+                        return Err(format!(
+                            "{}:{}: expected three scale factors on the first content line",
+                            inpfile, line_no
+                        ));
+                    }
                     // Independent scale factors for three lattice vectors.
-                    self.scale_a = s[0].parse().unwrap();
-                    self.scale_b = s[1].parse().unwrap();
-                    self.scale_c = s[2].parse().unwrap();
+                    scale_a = parse_f64_token(&s, 0, inpfile, line_no, "scale_a")?;
+                    scale_b = parse_f64_token(&s, 1, inpfile, line_no, "scale_b")?;
+                    scale_c = parse_f64_token(&s, 2, inpfile, line_no, "scale_c")?;
                 }
 
                 1 => {
+                    if s.len() < 6 {
+                        return Err(format!(
+                            "{}:{}: expected lattice vector a followed by three T/F mask flags",
+                            inpfile, line_no
+                        ));
+                    }
                     // Lattice vector a and optimization mask flags.
-                    vec_a[0] = s[0].parse().unwrap();
-                    vec_a[1] = s[1].parse().unwrap();
-                    vec_a[2] = s[2].parse().unwrap();
+                    vec_a[0] = parse_f64_token(&s, 0, inpfile, line_no, "a_x")?;
+                    vec_a[1] = parse_f64_token(&s, 1, inpfile, line_no, "a_y")?;
+                    vec_a[2] = parse_f64_token(&s, 2, inpfile, line_no, "a_z")?;
 
                     for iv in 0..3 {
-                        vec_a[iv] *= self.scale_a * ANG_TO_BOHR;
+                        vec_a[iv] *= scale_a * ANG_TO_BOHR;
                     }
 
-                    if s[3].to_lowercase() == "t" {
-                        self.cell_mask[(0, 0)] = 1.0;
-                    } else {
-                        self.cell_mask[(0, 0)] = 0.0;
-                    }
-
-                    if s[4].to_lowercase() == "t" {
-                        self.cell_mask[(1, 0)] = 1.0;
-                    } else {
-                        self.cell_mask[(1, 0)] = 0.0;
-                    }
-
-                    if s[5].to_lowercase() == "t" {
-                        self.cell_mask[(2, 0)] = 1.0;
-                    } else {
-                        self.cell_mask[(2, 0)] = 0.0;
-                    }
+                    cell_mask[(0, 0)] = parse_bool_mask(s[3], inpfile, line_no, "a_x")?;
+                    cell_mask[(1, 0)] = parse_bool_mask(s[4], inpfile, line_no, "a_y")?;
+                    cell_mask[(2, 0)] = parse_bool_mask(s[5], inpfile, line_no, "a_z")?;
                 }
 
                 2 => {
+                    if s.len() < 6 {
+                        return Err(format!(
+                            "{}:{}: expected lattice vector b followed by three T/F mask flags",
+                            inpfile, line_no
+                        ));
+                    }
                     // Lattice vector b and optimization mask flags.
-                    vec_b[0] = s[0].parse().unwrap();
-                    vec_b[1] = s[1].parse().unwrap();
-                    vec_b[2] = s[2].parse().unwrap();
+                    vec_b[0] = parse_f64_token(&s, 0, inpfile, line_no, "b_x")?;
+                    vec_b[1] = parse_f64_token(&s, 1, inpfile, line_no, "b_y")?;
+                    vec_b[2] = parse_f64_token(&s, 2, inpfile, line_no, "b_z")?;
 
                     for iv in 0..3 {
-                        vec_b[iv] *= self.scale_b * ANG_TO_BOHR;
+                        vec_b[iv] *= scale_b * ANG_TO_BOHR;
                     }
 
-                    if s[3].to_lowercase() == "t" {
-                        self.cell_mask[(0, 1)] = 1.0;
-                    } else {
-                        self.cell_mask[(0, 1)] = 0.0;
-                    }
-
-                    if s[4].to_lowercase() == "t" {
-                        self.cell_mask[(1, 1)] = 1.0;
-                    } else {
-                        self.cell_mask[(1, 1)] = 0.0;
-                    }
-
-                    if s[5].to_lowercase() == "t" {
-                        self.cell_mask[(2, 1)] = 1.0;
-                    } else {
-                        self.cell_mask[(2, 1)] = 0.0;
-                    }
+                    cell_mask[(0, 1)] = parse_bool_mask(s[3], inpfile, line_no, "b_x")?;
+                    cell_mask[(1, 1)] = parse_bool_mask(s[4], inpfile, line_no, "b_y")?;
+                    cell_mask[(2, 1)] = parse_bool_mask(s[5], inpfile, line_no, "b_z")?;
                 }
 
                 3 => {
+                    if s.len() < 6 {
+                        return Err(format!(
+                            "{}:{}: expected lattice vector c followed by three T/F mask flags",
+                            inpfile, line_no
+                        ));
+                    }
                     // Lattice vector c and optimization mask flags.
-                    vec_c[0] = s[0].parse().unwrap();
-                    vec_c[1] = s[1].parse().unwrap();
-                    vec_c[2] = s[2].parse().unwrap();
+                    vec_c[0] = parse_f64_token(&s, 0, inpfile, line_no, "c_x")?;
+                    vec_c[1] = parse_f64_token(&s, 1, inpfile, line_no, "c_y")?;
+                    vec_c[2] = parse_f64_token(&s, 2, inpfile, line_no, "c_z")?;
 
                     for iv in 0..3 {
-                        vec_c[iv] *= self.scale_c * ANG_TO_BOHR;
+                        vec_c[iv] *= scale_c * ANG_TO_BOHR;
                     }
 
-                    if s[3].to_lowercase() == "t" {
-                        self.cell_mask[(0, 2)] = 1.0;
-                    } else {
-                        self.cell_mask[(0, 2)] = 0.0;
-                    }
-
-                    if s[4].to_lowercase() == "t" {
-                        self.cell_mask[(1, 2)] = 1.0;
-                    } else {
-                        self.cell_mask[(1, 2)] = 0.0;
-                    }
-
-                    if s[5].to_lowercase() == "t" {
-                        self.cell_mask[(2, 2)] = 1.0;
-                    } else {
-                        self.cell_mask[(2, 2)] = 0.0;
-                    }
+                    cell_mask[(0, 2)] = parse_bool_mask(s[3], inpfile, line_no, "c_x")?;
+                    cell_mask[(1, 2)] = parse_bool_mask(s[4], inpfile, line_no, "c_y")?;
+                    cell_mask[(2, 2)] = parse_bool_mask(s[5], inpfile, line_no, "c_z")?;
                 }
 
                 // atoms
                 _ => {
-                    if s.len() == 0 {
-                        continue;
-                    };
+                    if s.len() < 4 {
+                        return Err(format!(
+                            "{}:{}: expected atomic line '<species> x y z'",
+                            inpfile, line_no
+                        ));
+                    }
 
                     let symbol = s[0].to_string();
-                    let x: f64 = s[1].parse().unwrap();
-                    let y: f64 = s[2].parse().unwrap();
-                    let z: f64 = s[3].parse().unwrap();
+                    let x = parse_f64_token(&s, 1, inpfile, line_no, "atom_x")?;
+                    let y = parse_f64_token(&s, 2, inpfile, line_no, "atom_y")?;
+                    let z = parse_f64_token(&s, 3, inpfile, line_no, "atom_z")?;
 
                     // Atomic position remains fractional.
-                    self.atom_species.push(symbol);
-                    self.atom_positions.push(Vector3f64::new(x, y, z));
+                    atom_species.push(symbol);
+                    atom_positions.push(Vector3f64::new(x, y, z));
                 }
             }
-
-            // Keep lattice object synchronized while parsing.
-            self.latt = Lattice::new(&vec_a, &vec_b, &vec_c);
+            content_line_index += 1;
         }
 
-        // Build specie -> atom-index lookup for fast grouped operations.
+        if content_line_index < 4 {
+            return Err(format!(
+                "{}: expected 4 non-empty header lines before atomic positions",
+                inpfile
+            ));
+        }
 
-        let unique_species: Vec<String> = self.get_unique_species();
+        let latt = Lattice::new(&vec_a, &vec_b, &vec_c);
+        // Build specie -> atom-index lookup for fast grouped operations.
+        let unique_species: Vec<String> = atom_species.clone().into_iter().unique().collect();
 
         let nsp = unique_species.len();
 
-        self.atom_indices_by_specie = vec![Vec::new(); nsp];
+        let mut atom_indices_by_specie = vec![Vec::new(); nsp];
 
-        for (at_index, at_symbol) in self.atom_species.iter().enumerate() {
+        for (at_index, at_symbol) in atom_species.iter().enumerate() {
             for (isp, sp) in unique_species.iter().enumerate() {
                 if *sp == *at_symbol {
-                    self.atom_indices_by_specie[isp].push(at_index);
+                    atom_indices_by_specie[isp].push(at_index);
                 }
             }
         }
+
+        self.scale_a = scale_a;
+        self.scale_b = scale_b;
+        self.scale_c = scale_c;
+        self.latt = latt;
+        self.cell_mask = cell_mask;
+        self.atom_positions = atom_positions;
+        self.atom_species = atom_species;
+        self.atom_indices_by_specie = atom_indices_by_specie;
+
+        Ok(())
     }
 
     pub fn output(&self) {
@@ -480,4 +535,32 @@ fn test_crystal() {
     crystal.read_file(d.to_str().unwrap());
     crystal.display();
     crystal.output();
+}
+
+#[test]
+fn test_try_read_file_reports_invalid_mask() {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock drift")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("dftworks-crystal-invalid-mask-{}", nanos));
+    let content = "\
+1.0 1.0 1.0
+1.0 0.0 0.0 X T T
+0.0 1.0 0.0 T T T
+0.0 0.0 1.0 T T T
+Si 0.0 0.0 0.0
+";
+    fs::write(&path, content).expect("write temp in.crystal");
+
+    let mut crystal = Crystal::new();
+    let err = crystal
+        .try_read_file(path.to_str().expect("temp path should be utf8"))
+        .expect_err("invalid in.crystal should fail");
+    assert!(err.contains("expected T or F"));
+
+    fs::remove_file(path).expect("remove temp in.crystal");
 }

--- a/pspot/src/lib.rs
+++ b/pspot/src/lib.rs
@@ -3,10 +3,22 @@ use atompsp::AtomPSP;
 use control::PotScheme;
 
 use std::{
+    any::Any,
     collections::HashMap,
     fs::File,
     io::{BufRead, BufReader},
+    panic::{catch_unwind, AssertUnwindSafe},
 };
+
+fn panic_payload_to_string(payload: Box<dyn Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else {
+        "unknown panic".to_string()
+    }
+}
 
 #[derive(Default)]
 pub struct PSPot {
@@ -18,28 +30,49 @@ pub struct PSPot {
 
 impl PSPot {
     pub fn new(scheme: PotScheme) -> PSPot {
+        match Self::try_new(scheme) {
+            Ok(pots) => pots,
+            Err(err) => panic!("{}", err),
+        }
+    }
+
+    pub fn try_new(scheme: PotScheme) -> Result<PSPot, String> {
         // Read species-to-file map from in.pot and instantiate parser by scheme.
-        let pspfiles = get_psp_files("in.pot");
+        let pspfiles = try_get_psp_files("in.pot")?;
 
         let mut pots = HashMap::new();
         let mut atpsp_file = HashMap::new();
 
         for (sp, spfile) in pspfiles.iter() {
-            let mut psp_one = atompsp::new(scheme.as_str());
-
-            psp_one.read_file(&spfile);
+            let psp_one = catch_unwind(AssertUnwindSafe(|| {
+                let mut psp_one = atompsp::new(scheme.as_str());
+                psp_one.read_file(spfile);
+                psp_one
+            }))
+            .map_err(|payload| {
+                format!(
+                    "failed to load pseudopotential '{}' for species '{}': {}",
+                    spfile,
+                    sp,
+                    panic_payload_to_string(payload)
+                )
+            })?;
 
             pots.insert(sp.clone(), psp_one);
 
             atpsp_file.insert(sp.clone(), spfile.clone());
         }
 
-        PSPot { pots, atpsp_file }
+        Ok(PSPot { pots, atpsp_file })
     }
 
     pub fn get_psp(&self, sp: &str) -> &dyn AtomPSP {
         // Fast lookup by species symbol.
         self.pots.get(sp).unwrap().as_ref()
+    }
+
+    pub fn contains_species(&self, sp: &str) -> bool {
+        self.pots.contains_key(sp)
     }
 
     pub fn get_max_lmax(&self) -> usize {
@@ -77,15 +110,36 @@ impl PSPot {
 }
 
 pub fn get_psp_files(inpfile: &str) -> HashMap<String, String> {
+    match try_get_psp_files(inpfile) {
+        Ok(files) => files,
+        Err(err) => panic!("{}", err),
+    }
+}
+
+pub fn try_get_psp_files(inpfile: &str) -> Result<HashMap<String, String>, String> {
     // in.pot format: "<species> <filename>" per line.
     // Filenames are resolved under "pot/" relative directory.
-    let file = File::open(inpfile).unwrap();
+    let file =
+        File::open(inpfile).map_err(|err| format!("failed to read '{}': {}", inpfile, err))?;
     let lines = BufReader::new(file).lines();
 
     let mut pspmap = HashMap::new();
 
-    for line in lines {
-        let s: Vec<&str> = line.as_ref().unwrap().split_whitespace().collect();
+    for (line_idx, line_res) in lines.enumerate() {
+        let line_no = line_idx + 1;
+        let line = line_res
+            .map_err(|err| format!("{}:{}: failed to read line: {}", inpfile, line_no, err))?;
+        let content = line.split('#').next().unwrap_or(&line);
+        let s: Vec<&str> = content.split_whitespace().collect();
+        if s.is_empty() {
+            continue;
+        }
+        if s.len() < 2 {
+            return Err(format!(
+                "{}:{}: expected '<species> <filename>'",
+                inpfile, line_no
+            ));
+        }
 
         let specie = s[0].to_string();
 
@@ -94,5 +148,40 @@ pub fn get_psp_files(inpfile: &str) -> HashMap<String, String> {
         pspmap.insert(specie, psp);
     }
 
-    pspmap
+    if pspmap.is_empty() {
+        return Err(format!(
+            "{}: no pseudopotential mappings found; expected '<species> <filename>' lines",
+            inpfile
+        ));
+    }
+
+    Ok(pspmap)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::try_get_psp_files;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_file(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock drift")
+            .as_nanos();
+        std::env::temp_dir().join(format!("dftworks-pspot-{}-{}", name, nanos))
+    }
+
+    #[test]
+    fn test_try_get_psp_files_reports_invalid_line() {
+        let path = temp_file("invalid.in.pot");
+        fs::write(&path, "Si\n").expect("write temp in.pot");
+
+        let err = try_get_psp_files(path.to_str().expect("temp path should be utf8"))
+            .expect_err("invalid in.pot should fail");
+        assert!(err.contains("expected '<species> <filename>'"));
+
+        fs::remove_file(path).expect("remove temp in.pot");
+    }
 }

--- a/pw/src/main.rs
+++ b/pw/src/main.rs
@@ -507,8 +507,9 @@ fn main() {
     // 4) optionally perform geometry optimization step
     // 5) export requested artifacts (charge/wfc/eig files)
     // first statement
+    let enable_alloc_stats = read_env_flag("PW_ALLOC_STATS");
+    ALLOC_STATS_ENABLED.store(enable_alloc_stats, Ordering::Relaxed);
     dwmpi::init();
-    ALLOC_STATS_ENABLED.store(read_env_flag("PW_ALLOC_STATS"), Ordering::Relaxed);
 
     // start the timer-main
 
@@ -680,7 +681,7 @@ fn main() {
             shutdown_and_exit(1);
         }
 
-        let should_exit = orchestration::outputs::evaluate_exit_and_finalize(
+        let should_exit = match orchestration::outputs::evaluate_exit_and_finalize(
             &control,
             geom_iter,
             &stress_total,
@@ -689,7 +690,15 @@ fn main() {
             &vkevecs,
             &vkscf,
             &phase.electronic_ctx,
-        );
+        ) {
+            Ok(should_exit) => should_exit,
+            Err(err) => {
+                if dwmpi::is_root() {
+                    eprintln!("{}", err);
+                }
+                shutdown_and_exit(1);
+            }
+        };
 
         if should_exit {
             break;

--- a/pw/src/orchestration/bootstrap.rs
+++ b/pw/src/orchestration/bootstrap.rs
@@ -68,11 +68,23 @@ pub(crate) fn load_bootstrap_inputs() -> Result<BootstrapData, String> {
     }
 
     let mut crystal = Crystal::new();
-    crystal.read_file("in.crystal");
+    crystal
+        .try_read_file("in.crystal")
+        .map_err(|err| format!("failed to load crystal file: {}", err))?;
 
-    let pots = PSPot::new(control.get_pot_scheme_enum());
+    let pots = PSPot::try_new(control.get_pot_scheme_enum())
+        .map_err(|err| format!("failed to load pseudopotentials: {}", err))?;
     if dwmpi::is_root() && verbosity >= VerbosityLevel::Normal {
         pots.display();
+    }
+
+    for species in crystal.get_unique_species().iter() {
+        if !pots.contains_species(species) {
+            return Err(format!(
+                "failed to load pseudopotentials: species '{}' appears in in.crystal but has no mapping in in.pot",
+                species
+            ));
+        }
     }
 
     let zions = crystal.get_zions(&pots);

--- a/pw/src/orchestration/outputs.rs
+++ b/pw/src/orchestration/outputs.rs
@@ -45,7 +45,7 @@ pub(crate) fn evaluate_exit_and_finalize(
     vkevecs: &VKEigenVector,
     vkscf: &VKSCF<'_>,
     electronic_ctx: &crate::ElectronicStepContext,
-) -> bool {
+) -> Result<bool, String> {
     let force_max = force::get_max_force(force_total);
     let stress_max = stress::get_max_stress(stress_total);
 
@@ -76,29 +76,23 @@ pub(crate) fn evaluate_exit_and_finalize(
 
     if should_exit {
         if control.get_wannier90_export() {
-            match wannier90::write_eig_inputs(control, vkevals, electronic_ctx.global_k_indices()) {
-                Ok(summary) => {
-                    if dwmpi::is_root() {
-                        println!();
-                        println!("   {:-^88}", " wannier90 eig export ");
-                        for file in summary.written_files.iter() {
-                            println!("   wrote {}", file);
-                        }
-                        println!(
-                            "   run `w90-win` and `w90-amn` to generate remaining Wannier90 inputs"
-                        );
-                    }
+            let summary =
+                wannier90::write_eig_inputs(control, vkevals, electronic_ctx.global_k_indices())
+                    .map_err(|err| format!("wannier90 eig export failed: {}", err))?;
+            if dwmpi::is_root() {
+                println!();
+                println!("   {:-^88}", " wannier90 eig export ");
+                for file in summary.written_files.iter() {
+                    println!("   wrote {}", file);
                 }
-                Err(err) => {
-                    if dwmpi::is_root() {
-                        eprintln!("   wannier90 eig export failed: {}", err);
-                    }
-                }
+                println!(
+                    "   run `w90-win` and `w90-amn` to generate remaining Wannier90 inputs"
+                );
             }
         }
 
         crate::post_processing(control, vkevals, vkevecs, vkscf);
     }
 
-    should_exit
+    Ok(should_exit)
 }

--- a/skills/dftworks-regression-testing/SKILL.md
+++ b/skills/dftworks-regression-testing/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: dftworks-regression-testing
+description: "Use for selecting and running DFTWorks validation and regression checks after code changes in pw, workflow, control, crystal, or pspot. Map touched areas to the lightest sufficient matrix: parser/unit tests, host or Docker cargo check for pw, phase12 regression, spin MPI parity, HSE06 regression, Hubbard +U regression, memory_estimate smoke, symmetry verification, workflow pipeline checks, and targeted Wannier example runs."
+---
+
+# DFTWorks Regression Testing
+
+## Overview
+
+Use this skill when a DFTWorks change needs validation beyond a single `cargo test`. Choose the smallest set of checks that covers the changed behavior, prefer existing repo scripts over ad hoc harnesses, and report exactly what ran versus what remained blocked.
+
+## Regression Workflow
+
+1. Start with the smallest relevant package tests.
+   For parser, control, or bootstrap changes, begin with the affected crate tests before touching heavier runtime suites.
+
+2. Add a `pw` build check for runtime-facing changes.
+   Run host `cargo check -p pw` if MPI is available. If host MPI is missing, use the Docker fallback in `references/execution-notes.md`.
+
+3. Escalate to behavior-specific regressions.
+   Use `references/regression-matrix.md` to map the changed area to phase12, spin/MPI parity, HSE06, Hubbard +U, memory-estimator, symmetry, workflow, or Wannier coverage.
+
+4. Prefer dedicated repo scripts.
+   Use `scripts/*.sh` or case-local runners such as `test_example/si-oncv/symmetry-enabled/run_and_verify.sh` before inventing new glue code.
+
+5. Keep the matrix proportional.
+   Do not run every heavy regression by default. Cover the code you changed and the nearest user-visible failure mode.
+
+6. Close with explicit validation notes.
+   State the commands you ran, which ones needed Docker or release binaries, and which suites you intentionally skipped.
+
+## Common Triggers
+
+- Changes under `pw/src` that affect SCF, energies, forces, stress, restart, export, finalization, or allocator diagnostics.
+- Changes under `control/src`, `crystal/src`, `pspot/src`, or bootstrap code that alter accepted inputs or runtime construction.
+- Changes under `workflow/src` or staged Wannier logic that can break `dwf` or multi-step artifact handoff.
+- XC-mode work such as spin, phase12, HSE06, or Hubbard +U.
+- Symmetry or k-point reduction changes that need example-driven verification.
+
+## References
+
+- Read `references/regression-matrix.md` to choose the right suites by changed area.
+- Read `references/execution-notes.md` for host-vs-Docker guidance, environment variables, and reporting expectations.

--- a/skills/dftworks-regression-testing/agents/openai.yaml
+++ b/skills/dftworks-regression-testing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DFTWorks Regression Testing"
+  short_description: "Choose and run DFTWorks regressions."
+  default_prompt: "Use $dftworks-regression-testing to choose and run the right DFTWorks validation and regression checks for this change."

--- a/skills/dftworks-regression-testing/references/execution-notes.md
+++ b/skills/dftworks-regression-testing/references/execution-notes.md
@@ -1,0 +1,47 @@
+# DFTWorks Regression Execution Notes
+
+## Host Versus Docker
+
+- Prefer host runs when the required toolchain is available, especially for scripts that expect local binaries or MPI launchers.
+- In this workspace, `docker` is already approval-allowed. If a regression needs Docker, run it directly instead of pausing for another permission prompt.
+- If host MPI is unavailable, use Docker for `cargo check -p pw`:
+
+```bash
+docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app rust-dev bash -lc 'source $HOME/.cargo/env && cargo check -p pw'
+```
+
+- The same container pattern can run non-MPI shell regressions when the host Rust toolchain is not usable:
+
+```bash
+docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app rust-dev bash -lc 'source $HOME/.cargo/env && bash scripts/run_phase12_regression.sh'
+```
+
+## Useful Script Knobs
+
+- `PW_BIN=/path/to/pw`: point a regression script at an already-built binary.
+- `FORCE_BUILD=1`: force the script to rebuild before running.
+- `CARGO_FEATURES=...`: build `pw` with explicit features when needed.
+- `KEEP_WORKDIR=1`: keep temporary regression directories for inspection in scripts that support it.
+- `MPI_LAUNCH`, `MPI_FLAG_N`, `MPI_RANKS_REF`, `MPI_RANKS_CMP`: tune the spin/MPI parity runner without editing the script.
+
+## Manual Example Runs
+
+- Wannier examples have concrete run instructions in:
+  `test_example/si-oncv/wannier90/README.md`
+  `test_example/si-oncv/wannier90-spin/README.md`
+  `test_example/si-oncv/wannier90-projected/README.md`
+
+- The workflow YAML pipeline example is documented in:
+  `test_example/si-oncv/workflow-pipeline-yaml/README.md`
+
+- The symmetry case has a dedicated runner:
+  `test_example/si-oncv/symmetry-enabled/run_and_verify.sh`
+
+## Reporting Expectations
+
+In the close-out, always state:
+
+- the exact commands you ran,
+- whether they ran on host or in Docker,
+- any environment assumptions such as MPI or external Wannier tools,
+- and which relevant regressions you did not run.

--- a/skills/dftworks-regression-testing/references/regression-matrix.md
+++ b/skills/dftworks-regression-testing/references/regression-matrix.md
@@ -1,0 +1,64 @@
+# DFTWorks Regression Matrix
+
+## Fast Baseline
+
+- `control/src` changes: `cargo test -p control`
+- `crystal/src` changes: `cargo test -p crystal`
+- `pspot/src` changes: `cargo test -p pspot`
+- Any runtime-facing `pw` change: `cargo check -p pw` on host if MPI works, otherwise use the Docker fallback from `execution-notes.md`
+
+## Script-Backed Regressions
+
+- SCF iteration summaries, spin/nonspin output parsing, XC toggles, or energy/Fermi regressions:
+  `bash scripts/run_phase12_regression.sh`
+  This covers LDA/LSDA/PBE across spin and nonspin cases and compares against `test_example/si-oncv/regression/phase12_reference.tsv`.
+
+- MPI decomposition, spin parity, forces, or stress consistency:
+  `bash scripts/run_spin_mpi_parity.sh`
+  Use this when a change could alter rank-dependent behavior or spin-path force/stress output.
+
+- Hybrid functional or exact-exchange changes:
+  `bash scripts/run_hse06_regression.sh`
+  This exercises the `test_example/si-oncv/hse06-gamma` case and checks convergence plus parsed SCF metrics.
+
+- Hubbard +U implementation changes:
+  `bash scripts/run_hubbard_u_regression.sh`
+  This compares baseline spin-PBE versus enabled Hubbard +U and requires a measurable energy shift.
+
+- Memory estimator changes:
+  `bash scripts/run_memory_estimator_smoke.sh`
+  Use this for `pw --bin memory_estimate` logic, case loading, or JSON/human-readable output changes.
+
+- Symmetry reduction, force balance, or stress tensor symmetry:
+  `bash test_example/si-oncv/symmetry-enabled/run_and_verify.sh`
+  This runs the symmetry-enabled Si SCF and relax cases and checks reduced `nkpt`, force sums, and stress symmetry.
+
+## Workflow And Wannier Coverage
+
+- `workflow/src` pipeline, staged run semantics, or status/provenance changes:
+  `cargo run -p workflow --bin dwf -- validate test_example/si-oncv/workflow-pipeline-yaml`
+  `cargo run -p workflow --bin dwf -- run pipeline test_example/si-oncv/workflow-pipeline-yaml`
+  `cargo run -p workflow --bin dwf -- status test_example/si-oncv/workflow-pipeline-yaml`
+
+- Nonspin Wannier export changes in `pw`, `w90-win`, or `w90-amn`:
+  Run the case in `test_example/si-oncv/wannier90` and verify `si.eig`, `si.win`, `si.nnkp`, `si.mmn`, and `si.amn` generation.
+
+- Spin-resolved Wannier export changes:
+  Run `test_example/si-oncv/wannier90-spin` and verify both `si.up.*` and `si.dn.*` artifact sets, especially `.eig`.
+
+- Projected Wannier or level-3 output changes:
+  Run `test_example/si-oncv/wannier90-projected` and, if projector/post-processing logic changed, also verify `w90-proj` outputs under `level3-out/`.
+
+## Selecting The Smallest Sufficient Matrix
+
+- Input-loader or bootstrap hardening:
+  Run the affected crate tests plus `cargo check -p pw`. Add a runtime script only if the change reaches execution semantics.
+
+- `pw/src/orchestration/outputs.rs`, restart, checkpoint, or export logic:
+  Run `cargo check -p pw` plus the nearest artifact-producing regression, usually a Wannier case or symmetry/script-backed runtime case.
+
+- `workflow/src/main.rs` changes:
+  Run the workflow pipeline commands even if lower-level unit tests pass.
+
+- Output-format or parser-only changes:
+  Use the narrowest script that exercises that output path, usually `run_phase12_regression.sh`, `run_spin_mpi_parity.sh`, or `run_memory_estimator_smoke.sh`.

--- a/skills/dftworks-runtime-hardening/SKILL.md
+++ b/skills/dftworks-runtime-hardening/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: dftworks-runtime-hardening
+description: Use for implementing and validating DFTWorks runtime-path fixes in pw, control, crystal, pspot, restart/checkpoint, or output/finalization code. Follow the repo's patterns for replacing panics with Result-based boundaries, preserving MPI-safe shutdown, and validating changes with host tests plus Docker cargo check for pw when MPI is unavailable.
+---
+
+# DFTWorks Runtime Hardening
+
+## Overview
+
+Use this skill when the task is to fix runtime-path issues in DFTWorks rather than just review them. It is for changes that harden bootstrap, validation, restart, persistence, export, or shutdown behavior.
+
+## When To Use
+
+- A runtime review found swallowed errors, panic-based loaders, or incorrect success exits.
+- You need to add or tighten early validation for runtime modes, inputs, or cross-file consistency.
+- You are converting boundary APIs to `try_*`/`Result` while keeping compatibility for older callers.
+- You need to validate runtime-path fixes without relying on host MPI availability.
+
+## Hardening Workflow
+
+1. Trace the failing path end-to-end.
+   Follow the call chain from parser/input boundary to `pw` bootstrap, orchestration, finalization, and `shutdown_and_exit`.
+
+2. Harden the boundary first.
+   Prefer adding a fallible `try_*` API at file-loading or orchestration boundaries. Keep an existing panic wrapper only if other callers still rely on it.
+
+3. Preserve process semantics.
+   In `pw`, final user-visible runtime failures should propagate back to `main` and terminate through `shutdown_and_exit(1)`. Do not replace a hard failure with a warning unless the feature is explicitly optional.
+
+4. Add cross-file checks when needed.
+   If one file references species, modes, or artifacts defined elsewhere, validate that relationship during bootstrap rather than letting it fail much later.
+
+5. Add small regression tests close to the parser or helper you changed.
+   Use temp files for malformed `in.crystal` / `in.pot`-style cases instead of broad integration tests when the bug is boundary-local.
+
+6. Validate with the standard sequence.
+   Use `scripts/validate_runtime_changes.sh` for the common unit-test plus `pw` check flow, and read `references/validation.md` for the rationale and fallbacks.
+
+## Expected Implementation Patterns
+
+- Boundary loaders: `read_file()` may keep panic behavior for legacy callers, but add `try_read_file()` or equivalent for runtime bootstrap.
+- Finalization/export: return `Result` up the call chain if an artifact is required for a successful run.
+- Diagnostics: if a counter or metric claims to cover runtime behavior, enable it before the relevant allocations/work begin or explicitly track generations/phases.
+
+## References
+
+- Read `references/runtime-hardening.md` for repo-specific implementation rules.
+- Read `references/validation.md` before closing out a runtime fix.

--- a/skills/dftworks-runtime-hardening/agents/openai.yaml
+++ b/skills/dftworks-runtime-hardening/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DFTWorks Runtime Hardening"
+  short_description: "Harden DFTWorks runtime paths."
+  default_prompt: "Use $dftworks-runtime-hardening to implement and validate DFTWorks runtime-path fixes."

--- a/skills/dftworks-runtime-hardening/references/runtime-hardening.md
+++ b/skills/dftworks-runtime-hardening/references/runtime-hardening.md
@@ -1,0 +1,42 @@
+# DFTWorks Runtime Hardening Notes
+
+## Preferred Fix Shapes
+
+### Input/bootstrap hardening
+
+- Add a fallible `try_*` API at the boundary.
+- Return line/file-aware messages for malformed inputs where practical.
+- Let `pw/src/orchestration/bootstrap.rs` own cross-file consistency checks.
+
+### Finalization/export hardening
+
+- If an export is required for a successful run, do not just print a warning.
+- Return `Result` from orchestration helpers and let `pw/src/main.rs` terminate with `shutdown_and_exit(1)`.
+
+### Capability/runtime alignment
+
+- If `control` parses a mode, either:
+  - the runtime must consume it correctly, or
+  - bootstrap/preflight must reject it early with a clear message.
+
+### Optional diagnostics
+
+- Make sure measurement starts before the measured work begins.
+- If not possible, explicitly track the measurement window instead of reporting totals that span multiple phases.
+
+## Files To Check While Editing
+
+- `pw/src/main.rs`
+- `pw/src/orchestration/bootstrap.rs`
+- `pw/src/orchestration/outputs.rs`
+- `pw/src/restart.rs`
+- `control/src/lib.rs`
+- `crystal/src/lib.rs`
+- `pspot/src/lib.rs`
+
+## Avoid
+
+- Silent downgrade from failure to warning for required artifacts.
+- Introducing `process::exit` outside the top-level runtime path.
+- Broad refactors when a narrow boundary fix is enough.
+- Staging generated run artifacts while testing.

--- a/skills/dftworks-runtime-hardening/references/validation.md
+++ b/skills/dftworks-runtime-hardening/references/validation.md
@@ -1,0 +1,34 @@
+# Runtime Hardening Validation
+
+## Default Validation Set
+
+Run the smallest relevant set that covers the changed boundary:
+
+```bash
+cargo test -p control
+cargo test -p crystal
+cargo test -p pspot
+```
+
+## `pw` Validation
+
+If host MPI is available, host `cargo check -p pw` is fine.
+
+If host MPI is not available, use Docker:
+
+```bash
+docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app rust-dev bash -lc 'source $HOME/.cargo/env && cargo check -p pw'
+```
+
+## When To Go Further
+
+- If runtime behavior or artifacts changed beyond parsing/control flow, consider the regression scripts in `README.md`.
+- If a workflow wrapper assumption changed, inspect `workflow/src/main.rs` as well.
+
+## Reporting
+
+In the close-out, state:
+
+- what you ran,
+- what needed Docker,
+- and any validation you could not run.

--- a/skills/dftworks-runtime-hardening/scripts/validate_runtime_changes.sh
+++ b/skills/dftworks-runtime-hardening/scripts/validate_runtime_changes.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$repo_root"
+
+echo "== cargo test -p control =="
+cargo test -p control
+
+echo "== cargo test -p crystal =="
+cargo test -p crystal
+
+echo "== cargo test -p pspot =="
+cargo test -p pspot
+
+if command -v mpicc >/dev/null 2>&1; then
+  echo "== cargo check -p pw (host MPI detected) =="
+  cargo check -p pw
+  exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: host MPI is unavailable and docker is not installed; cannot validate pw" >&2
+  exit 1
+fi
+
+echo "== docker cargo check -p pw =="
+docker run --rm -v "$repo_root":/usr/src/app -w /usr/src/app rust-dev bash -lc 'source $HOME/.cargo/env && cargo check -p pw'

--- a/skills/dftworks-runtime-review/SKILL.md
+++ b/skills/dftworks-runtime-review/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: dftworks-runtime-review
+description: Use for code reviews of DFTWorks runtime-path changes in pw, control, crystal, pspot, restart/checkpoint, or output/finalization logic. Focus on swallowed errors, panic-based input loading, unsupported-mode leaks, checkpoint/export correctness, exit-code behavior, and validation gaps.
+---
+
+# DFTWorks Runtime Review
+
+## Overview
+
+Use this skill when reviewing changes that affect how DFTWorks starts, validates inputs, runs SCF/runtime orchestration, persists artifacts, or exits. Prioritize real execution risks and behavioral regressions over style.
+
+## When To Use
+
+- Changes under `pw/src`, especially `main.rs`, `orchestration/`, `restart.rs`, and runtime display or diagnostics.
+- Changes under `control/src`, `crystal/src`, `pspot/src`, or other input/bootstrap layers.
+- Changes touching checkpoint loading/saving, Wannier export, provenance, output files, or exit behavior.
+- Reviews of capability-matrix work, unsupported modes, restart semantics, or optional diagnostics like allocator statistics.
+
+## Review Workflow
+
+1. Map the runtime path first.
+   Typical path: `control`/input parse -> bootstrap -> geometry/electronic construction -> SCF run -> output persistence -> finalization -> shutdown.
+
+2. Review boundaries before internals.
+   Check file parsing, `Result` propagation, mode validation, restart preflight, export/finalization, and process exit behavior before worrying about local implementation details.
+
+3. Treat these as high-risk bug classes.
+   - Parsed configuration that is never enforced at runtime.
+   - `Err` branches that only log and continue.
+   - Panic-based file/input loading after MPI or runtime setup has already started.
+   - Export/checkpoint failures that still produce `exit 0`.
+   - Capability matrix acceptance that does not match real implementation.
+   - Generated artifacts or caches that can mask missing outputs.
+
+4. Prefer concrete findings.
+   Report the user-visible failure mode, the exact file/line, and why the current control flow allows it.
+
+5. Validate what you can.
+   Use the commands in `references/review-checklist.md`. If host `pw` validation is blocked by missing MPI, use the Docker fallback and say so explicitly.
+
+## Output Expectations
+
+- Findings first, ordered by severity.
+- Include file and line references.
+- Keep summaries brief.
+- If nothing is found, say that explicitly and mention residual testing gaps.
+
+## References
+
+- Read `references/review-checklist.md` for the DFTWorks-specific hotspots and validation sequence.

--- a/skills/dftworks-runtime-review/agents/openai.yaml
+++ b/skills/dftworks-runtime-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DFTWorks Runtime Review"
+  short_description: "Review DFTWorks runtime-path changes."
+  default_prompt: "Use $dftworks-runtime-review to review DFTWorks runtime-path changes for bugs and regressions."

--- a/skills/dftworks-runtime-review/references/review-checklist.md
+++ b/skills/dftworks-runtime-review/references/review-checklist.md
@@ -1,0 +1,50 @@
+# DFTWorks Runtime Review Checklist
+
+## Primary Runtime Path
+
+Review these in order when a change looks runtime-facing:
+
+1. `control/src/lib.rs`
+2. `crystal/src/lib.rs`
+3. `pspot/src/lib.rs`
+4. `pw/src/orchestration/bootstrap.rs`
+5. `pw/src/orchestration/construction.rs`
+6. `scf/src/*` and `kscf/src/*` if execution semantics changed
+7. `pw/src/orchestration/outputs.rs`
+8. `pw/src/restart.rs`
+9. `pw/src/main.rs`
+
+## High-Signal Questions
+
+- Does the parser accept a mode or option that the runtime never consumes?
+- If a boundary function can fail, does it return `Result` or panic?
+- After MPI/runtime init, does any malformed input still crash instead of cleanly reporting an error?
+- If an export/checkpoint/provenance step fails, does the program still finish successfully?
+- Are saved artifacts aligned with the requested mode (`save_rho`, `save_wfc`, Wannier export, restart)?
+- Do optional diagnostics measure what they claim to measure, or are they mixing states/phases?
+
+## Common Finding Patterns In This Repo
+
+- `unwrap()` / `panic!()` in input loaders and bootstrap helpers.
+- Capability matrix added in `control`, but no matching enforcement deeper in `pw`.
+- Finalization code that prints a warning and keeps going.
+- Restart preflight and output persistence using slightly different invariants.
+- Workflow wrapper stages assuming semantics that `pw` itself does not honor.
+
+## Validation Commands
+
+Run the smallest relevant set:
+
+```bash
+cargo test -p control
+cargo test -p crystal
+cargo test -p pspot
+```
+
+For `pw`, prefer host first only if MPI is available. Otherwise use Docker:
+
+```bash
+docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app rust-dev bash -lc 'source $HOME/.cargo/env && cargo check -p pw'
+```
+
+If the review is broader than API/control-flow inspection, also consider the repo regression scripts documented in `README.md`.


### PR DESCRIPTION
Summary
- fail pw runs when required Wannier .eig export fails instead of logging and exiting 0
- replace panic-based crystal/pot bootstrap loading with structured errors and tighter bootstrap validation
- enable allocation stats before runtime setup so reported memory accounting matches the measured phase
- add project-local runtime review, runtime hardening, and regression testing skills plus AGENTS guidance

Validation
- cargo test -p crystal
- cargo test -p pspot
- docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app rust-dev bash -lc 'source $HOME/.cargo/env && cargo check -p pw'

Notes
- branch: dev
- commits: 5bcac5a, f209915, 5c86026